### PR TITLE
fix: use `vim.treesitter` instead of `nvim-treesitter` API

### DIFF
--- a/lua/pyrola/init.lua
+++ b/lua/pyrola/init.lua
@@ -1,5 +1,4 @@
 local api, ts = vim.api, vim.treesitter
-local parsers = require "nvim-treesitter.parsers"
 
 local M = {
     config = {
@@ -368,7 +367,7 @@ end
 
 function M.send_statement_definition()
     handle_cursor_move()
-    local parser = parsers.get_parser(0)
+    local parser = assert(vim.treesitter.get_parser(0))
     local root = parser:parse()[1]:root()
     local node = vim.treesitter.get_node()
 


### PR DESCRIPTION
This PR uses the `vim.treesitter.get_parser` from core instead of the one from `nvim-treesitter`. I am using `assert` to maintain the error handling, as since v0.12 `get_parser` returns `nil` instead of throwing when no parser is found.

Closes #4.